### PR TITLE
19544 - EFT short name history invoice refund tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fas-ui",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fas-ui",
-      "version": "1.3.12",
+      "version": "1.3.13",
       "dependencies": {
         "@bcrs-shared-components/base-address": "^2.0.3",
         "@bcrs-shared-components/enums": "^1.0.51",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fas-ui",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "private": true,
   "main": "./lib/lib.umd.min.js",
   "appName": "FAS UI",

--- a/src/components/eft/ShortNamePaymentHistory.vue
+++ b/src/components/eft/ShortNamePaymentHistory.vue
@@ -312,7 +312,8 @@ export default defineComponent({
     function formatAdditionalDescription (item: any) {
       switch (item.transactionType) {
         case ShortNameHistoryType.INVOICE_REFUND:
-          return item.invoiceId
+        case ShortNameHistoryType.INVOICE_PARTIAL_REFUND:
+          return `Invoice ID: ${item.invoiceId}`
         case ShortNameHistoryType.SN_REFUND_PENDING_APPROVAL:
           return 'Refund Requested'
         case ShortNameHistoryType.SN_REFUND_APPROVED:

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -200,6 +200,7 @@ export enum ShortNamePaymentActions {
 export enum ShortNameHistoryType {
   FUNDS_RECEIVED = 'FUNDS_RECEIVED',
   INVOICE_REFUND = 'INVOICE_REFUND',
+  INVOICE_PARTIAL_REFUND = 'INVOICE_PARTIAL_REFUND',
   STATEMENT_PAID = 'STATEMENT_PAID',
   STATEMENT_REVERSE = 'STATEMENT_REVERSE',
   SN_REFUND_PENDING_APPROVAL = 'SN_REFUND_PENDING_APPROVAL',
@@ -209,7 +210,8 @@ export enum ShortNameHistoryType {
 
 export enum ShortNameHistoryTypeDescription {
   FUNDS_RECEIVED = 'Funds Received',
-  INVOICE_REFUND = 'Invoice Refund',
+  INVOICE_REFUND = 'Full Invoice Refund',
+  INVOICE_PARTIAL_REFUND = 'Partial Invoice Refund',
   STATEMENT_PAID = 'Statement Paid',
   STATEMENT_REVERSE = 'Payment Reversed',
   SN_REFUND_PENDING_APPROVAL = 'Short Name Refund Request',


### PR DESCRIPTION
*Issue #:* /bcgov/entity/#19544

*Description of changes:*
- Updates to differentiate invoice refund types and labeling tweak

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
