### PR TITLE
28898 - EFT Short name history updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fas-ui",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fas-ui",
-      "version": "1.3.14",
+      "version": "1.3.15",
       "dependencies": {
         "@bcrs-shared-components/base-address": "^2.0.3",
         "@bcrs-shared-components/enums": "^1.0.51",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fas-ui",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "private": true,
   "main": "./lib/lib.umd.min.js",
   "appName": "FAS UI",

--- a/src/assets/scss/tooltips.scss
+++ b/src/assets/scss/tooltips.scss
@@ -1,0 +1,20 @@
+.v-tooltip__content {
+  margin-top: -2px;
+  background-color: RGBA(73, 80, 87, .95);
+  padding: 12px;
+}
+
+.top-tooltip:after {
+  content: ' ';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-top: -2px;
+  margin-left: -9px;
+  width: 20px;
+  height: 20px;
+  border-width: 10px 10px 10px 10px;
+  border-style: solid;
+  border-color: transparent transparent RGBA(73, 80, 87, .95) transparent;
+  transform: rotate(180deg);
+}

--- a/src/components/eft/ShortNameAccountLink.vue
+++ b/src/components/eft/ShortNameAccountLink.vue
@@ -616,6 +616,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+@import '$assets/scss/tooltips.scss';
 @import '$assets/scss/theme.scss';
 @import '$assets/scss/actions.scss';
 @import '$assets/scss/ShortnameTables.scss';
@@ -720,24 +721,5 @@ export default defineComponent({
   .disabled-action {
     pointer-events: none;
     opacity: 0.4;
-  }
-  .v-tooltip__content {
-    margin-top: -2px;
-    background-color: RGBA(73, 80, 87, .95);
-  }
-
-  .top-tooltip:after {
-    content: ' ';
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    margin-top: -2px;
-    margin-left: -9px;
-    width: 20px;
-    height: 20px;
-    border-width: 10px 10px 10px 10px;
-    border-style: solid;
-    border-color: transparent transparent RGBA(73, 80, 87, .95) transparent;
-    transform: rotate(180deg);
   }
 </style>

--- a/src/components/eft/ShortNamePaymentHistory.vue
+++ b/src/components/eft/ShortNamePaymentHistory.vue
@@ -99,11 +99,23 @@
         </h2>
       </template>
       <template #header-filter-slot />
-      <template #item-slot-transactionDate="{ item }">
-        <span>{{ formatDate(item.transactionDate, dateDisplayFormat) }}</span>
+      <template #item-slot-createdOn="{ item }">
+        <span>{{ formatDate(item.createdOn, dateDisplayFormat) }}</span>
       </template>
       <template #item-slot-transactionDescription="{ item }">
         <span>{{ formatDescription(item) }}</span>
+        <v-tooltip
+          v-if="getDescriptionTooltip(item)"
+          top>
+          <template #activator="{ on }">
+             <span v-on="on">
+              <v-icon
+                data-test="info-icon"
+                class='info-icon ml-1'>mdi-information-outline</v-icon>
+            </span>
+          </template>
+          <span class="top-tooltip" v-sanitize="getDescriptionTooltip(item)"></span>
+        </v-tooltip>
         <span class="transaction-details" :class="{ 'error-text': item.eftRefundChequeStatus === chequeRefundCodes.CHEQUE_UNDELIVERABLE }">
           {{ formatAdditionalDescription(item) }}
         </span>
@@ -186,7 +198,7 @@ export default defineComponent({
   },
   setup (props, { emit, root }) {
     const dateDisplayFormat = 'MMMM D, YYYY'
-
+    const formatDate = CommonUtils.formatUtcToPacificDate
     const shortNameRefundTypes: string[] = [
       ShortNameHistoryType.SN_REFUND_PENDING_APPROVAL,
       ShortNameHistoryType.SN_REFUND_APPROVED,
@@ -196,7 +208,7 @@ export default defineComponent({
     const historyTable: Ref<InstanceType<typeof BaseVDataTable>> = ref(null)
     const headers = [
       {
-        col: 'transactionDate',
+        col: 'createdOn',
         hasFilter: false,
         width: '200px',
         value: 'Date'
@@ -309,6 +321,14 @@ export default defineComponent({
       return shortNameRefundTypes.includes(item.transactionType)
     }
 
+    function getDescriptionTooltip (item: any) {
+      if (item.transactionType === ShortNameHistoryType.FUNDS_RECEIVED) {
+        const systemCreateDate = formatDate(item.createdOn, dateDisplayFormat)
+        const depositDate = formatDate(item.transactionDate, dateDisplayFormat)
+        return `Funds transfer deposited on ${depositDate} <br/>and became available on ${systemCreateDate}`
+      }
+    }
+
     function formatAdditionalDescription (item: any) {
       switch (item.transactionType) {
         case ShortNameHistoryType.INVOICE_REFUND:
@@ -323,6 +343,8 @@ export default defineComponent({
           return 'Request Approved'
         case ShortNameHistoryType.SN_REFUND_DECLINED:
           return 'Refund Declined'
+        case ShortNameHistoryType.FUNDS_RECEIVED:
+          return `Deposit Date: ${formatDate(item.transactionDate, dateDisplayFormat)}`
         default:
           return CommonUtils.formatAccountDisplayName(item) ? item.accountId && item.accountName : ''
       }
@@ -452,7 +474,7 @@ export default defineComponent({
       historyTable,
       formatBalanceAmount,
       formatTransactionAmount,
-      formatDate: CommonUtils.formatUtcToPacificDate,
+      formatDate: formatDate,
       dateDisplayFormat,
       formatAdditionalDescription,
       formatDescription,
@@ -467,13 +489,15 @@ export default defineComponent({
       calculateTableHeight,
       viewRefundDetails,
       isEftRefundApprover,
-      chequeRefundCodes
+      chequeRefundCodes,
+      getDescriptionTooltip
     }
   }
 })
 </script>
 
 <style lang="scss" scoped>
+@import '$assets/scss/tooltips.scss';
 @import '$assets/scss/theme.scss';
 @import '$assets/scss/actions.scss';
 @import '$assets/scss/ShortnameTables.scss';
@@ -517,6 +541,15 @@ export default defineComponent({
   .v-btn {
     width: 106px
   }
+}
+
+.info-icon {
+  color: $app-blue !important;
+  transform: translateY(-1px);
+}
+
+.v-tooltip__content {
+  background-color: RGBA(73, 80, 87, .95);
 }
 
 </style>

--- a/src/components/eft/ShortNamePaymentHistory.vue
+++ b/src/components/eft/ShortNamePaymentHistory.vue
@@ -548,8 +548,4 @@ export default defineComponent({
   transform: translateY(-1px);
 }
 
-.v-tooltip__content {
-  background-color: RGBA(73, 80, 87, .95);
-}
-
 </style>

--- a/tests/unit/components/eft/ShortNamePaymentHistory.spec.ts
+++ b/tests/unit/components/eft/ShortNamePaymentHistory.spec.ts
@@ -1,7 +1,6 @@
 import { Wrapper, createLocalVue, mount } from '@vue/test-utils'
 import { BaseVDataTable } from '@/components/datatable'
 import CommonUtils from '@/util/common-util'
-import { Role } from '@/util/constants'
 import ShortNameTransactions from '@/components/eft/ShortNamePaymentHistory.vue'
 import { VueConstructor } from 'vue'
 import Vuetify from 'vuetify'
@@ -9,6 +8,7 @@ import { axios } from '@/util/http-util'
 import { baseVdataTable } from '../../test-data/baseVdata'
 import { setupIntersectionObserverMock } from '../../util/helper-functions'
 import sinon from 'sinon'
+import { ShortNameHistoryType } from '@/util/constants'
 
 sessionStorage.setItem('AUTH_API_CONFIG', JSON.stringify({
   AUTH_API_URL: 'https://localhost:8080/api/v1',
@@ -44,6 +44,7 @@ describe('ShortNamePaymentHistory.vue', () => {
           shortNameId: 2,
           statementNumber: 5374449,
           invoiceId: 12345,
+          createdOn: '2024-08-01T00:01:30.885474',
           transactionDate: '2024-08-01T00:01:30.885474',
           transactionType: 'INVOICE_REFUND'
         },
@@ -58,6 +59,7 @@ describe('ShortNamePaymentHistory.vue', () => {
           shortNameBalance: 368.5,
           shortNameId: 2,
           statementNumber: 5374449,
+          createdOn: '2024-08-01T00:01:30.885474',
           transactionDate: '2024-08-01T00:01:30.885474',
           transactionType: 'STATEMENT_REVERSE'
         },
@@ -72,21 +74,8 @@ describe('ShortNamePaymentHistory.vue', () => {
           shortNameBalance: 368.5,
           shortNameId: 2,
           statementNumber: 5455966,
+          createdOn: '2024-07-31T22:22:31.058547',
           transactionDate: '2024-07-31T22:22:31.058547',
-          transactionType: 'STATEMENT_PAID'
-        },
-        {
-          accountBranch: 'Sushi Division',
-          accountId: '3202',
-          accountName: 'Odysseus Chiu',
-          amount: 351.5,
-          historicalId: 4,
-          isProcessing: false,
-          isReversible: false,
-          shortNameBalance: 17.0,
-          shortNameId: 2,
-          statementNumber: 5374449,
-          transactionDate: '2024-07-31T00:00:00',
           transactionType: 'STATEMENT_PAID'
         },
         {
@@ -100,14 +89,27 @@ describe('ShortNamePaymentHistory.vue', () => {
           shortNameBalance: 318.5,
           shortNameId: 2,
           statementNumber: 5374450,
+          createdOn: '2025-03-17T10:00:00',
           transactionDate: '2025-03-17T10:00:00',
           transactionType: 'SN_REFUND_APPROVED',
           eftRefundChequeStatus: 'CHEQUE_UNDELIVERABLE'
+        },
+        {
+          accountBranch: 'Sushi Division',
+          accountId: '3202',
+          accountName: 'Jia Xu',
+          amount: 100,
+          historicalId: 7,
+          isProcessing: false,
+          isReversible: false,
+          shortNameBalance: 100,
+          shortNameId: 2,
+          statementNumber: 5374450,
+          createdOn: '2025-03-17T10:00:00',
+          transactionDate: '2025-03-15T10:00:00',
+          transactionType: 'FUNDS_RECEIVED'
         }
-      ],
-      limit: 5,
-      page: 1,
-      total: 5
+      ]
     }
 
     sandbox = sinon.createSandbox()
@@ -158,7 +160,7 @@ describe('ShortNamePaymentHistory.vue', () => {
     for (let i = 0; i < historyResponse.items.length; i++) {
       const columns = itemRows.at(i).findAll(itemCell)
       expect(columns.at(0).text()).toBe(
-        CommonUtils.formatUtcToPacificDate(historyResponse.items[i].transactionDate, wrapper.vm.dateDisplayFormat))
+        CommonUtils.formatUtcToPacificDate(historyResponse.items[i].createdOn, wrapper.vm.dateDisplayFormat))
       expect(columns.at(1).text()).toContain(wrapper.vm.formatDescription(historyResponse.items[i]))
       expect(columns.at(1).text()).toContain(wrapper.vm.formatAdditionalDescription(historyResponse.items[i]))
       expect(columns.at(2).text()).toBe(historyResponse.items[i].statementNumber
@@ -169,6 +171,10 @@ describe('ShortNamePaymentHistory.vue', () => {
         expect(columns.at(4).find("[data-test='reverse-payment-btn']").exists()).toBeTruthy()
       } else {
         expect(columns.at(4).find("[data-test='reverse-payment-btn']").exists()).toBeFalsy()
+      }
+
+      if (historyResponse.items[i].transactionType === ShortNameHistoryType.FUNDS_RECEIVED) {
+        expect(wrapper.find('[data-test="info-icon"]').exists()).toBeTruthy()
       }
     }
   })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#28898

*Description of changes:*
- Replace createdOn as the main date for short name history, transactionDate is additional information that may come from an external source such as the TDI17
- add short name history description tool tip support
- moved tool tip styling to a separate file for re-usability


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).

![Screenshot 2025-06-09 at 1 21 14 PM](https://github.com/user-attachments/assets/2b4fbd0e-a21a-4553-943c-5e13858949db)

![Screenshot 2025-06-09 at 1 21 24 PM](https://github.com/user-attachments/assets/e9cced83-17b6-43dc-80b3-f80fb482530c)


